### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,6 +3,9 @@
 
 name: Swift
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/memoANDtimekensan/security/code-scanning/1](https://github.com/hrmcngs/memoANDtimekensan/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations (e.g., checking out the repository and running build/test commands). This change ensures that no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
