### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -3,6 +3,9 @@
 
 name: Swift
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/memoANDtimekensan/security/code-scanning/2](https://github.com/hrmcngs/memoANDtimekensan/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access, we can set the permissions to `contents: read` at the root level. This ensures that all jobs in the workflow inherit the least privilege required to complete their tasks.

The changes will be made to the `.github/workflows/swift.yml` file:
1. Add a `permissions` block at the root level of the workflow.
2. Set `contents: read` to limit the `GITHUB_TOKEN` permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
